### PR TITLE
Nuke RRO targets

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -23,11 +23,11 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay-lineage
 
 PRODUCT_ENFORCE_RRO_TARGETS := \
-    Bluetooth \
-    Settings \
-    SettingsProvider \
-    SystemUI \
-    framework-res \
+  #  Bluetooth \
+  #  Settings \
+  #  SettingsProvider \
+  #  SystemUI \
+  #  framework-res \
 
 # Screen density
 PRODUCT_AAPT_CONFIG := normal


### PR DESCRIPTION
RRO is not needed for rosy